### PR TITLE
Problem with directories on wsl linux

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -22,7 +22,6 @@ const (
 
 // DefaultPath is a default path for storing the wallpapers.
 func DefaultPath() string {
-
 	p := path.Join(xdg.UserDirs.Pictures, "GoSiMac")
 	if _, err := os.Stat(p); err != nil {
 		if err := os.MkdirAll(p, DirectoryPermission); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -24,10 +24,6 @@ const (
 func DefaultPath() string {
 
 	p := path.Join(xdg.UserDirs.Pictures, "GoSiMac")
-	if _, err := os.Stat("/proc/sys/fs/binfmt_misc/WSLInterop"); err == nil { //running on wsl (windows subsystem for linux)
-		log.Println("Program is running in a WSL environment")
-		p = path.Join(xdg.Home, "Pictures", "GoSiMac")
-	}
 	if _, err := os.Stat(p); err != nil {
 		if err := os.MkdirAll(p, DirectoryPermission); err != nil {
 			log.Fatalf("os.Mkdir: %v", err)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -22,9 +22,14 @@ const (
 
 // DefaultPath is a default path for storing the wallpapers.
 func DefaultPath() string {
+
 	p := path.Join(xdg.UserDirs.Pictures, "GoSiMac")
+	if _, err := os.Stat("/proc/sys/fs/binfmt_misc/WSLInterop"); err == nil { //running on wsl (windows subsystem for linux)
+		log.Println("Program is running in a WSL environment")
+		p = path.Join(xdg.Home, "Pictures", "GoSiMac")
+	}
 	if _, err := os.Stat(p); err != nil {
-		if err := os.Mkdir(p, DirectoryPermission); err != nil {
+		if err := os.MkdirAll(p, DirectoryPermission); err != nil {
 			log.Fatalf("os.Mkdir: %v", err)
 		}
 	}


### PR DESCRIPTION
There is problem when using gosimac on windows subsystem for Linux 
the problem is there is not /Pictures Directory inside wsl but `xdg.UserDirs.Pictures` contains `/Pictures` directory 
this pull request will fix it by using `MkdirAll `method so if no directory was found it will create it 